### PR TITLE
TestCurrency: remove access control

### DIFF
--- a/contracts/TestCurrency.sol
+++ b/contracts/TestCurrency.sol
@@ -2,37 +2,29 @@
 pragma solidity ^0.8.0;
 
 import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
-import {AccessControl} from "@openzeppelin/contracts/access/AccessControl.sol";
 
-contract TestCurrency is ERC20, AccessControl {
-  bytes32 public constant MINTER_ROLE = keccak256("MINTER_ROLE");
-  bytes32 public constant BURNER_ROLE = keccak256("BURNER_ROLE");
-
+contract TestCurrency is ERC20 {
   uint8 internal immutable _decimals;
 
   constructor(
     string memory name_,
     string memory symbol_,
     uint256 initialSupply,
-    uint8 decimals_,
-    address admin
+    uint8 decimals_
   ) ERC20(name_, symbol_) {
     _decimals = decimals_;
     _mint(msg.sender, initialSupply);
-    _grantRole(DEFAULT_ADMIN_ROLE, admin);
   }
 
   function decimals() public view virtual override returns (uint8) {
     return _decimals;
   }
 
-  function mint(address recipient, uint256 amount) external onlyRole(MINTER_ROLE) {
-    // require(msg.sender == _owner, "Only owner can mint");
+  function mint(address recipient, uint256 amount) public virtual {
     return _mint(recipient, amount);
   }
 
-  function burn(address recipient, uint256 amount) external onlyRole(BURNER_ROLE) {
-    // require(msg.sender == _owner, "Only owner can burn");
+  function burn(address recipient, uint256 amount) public virtual {
     return _burn(recipient, amount);
   }
 }

--- a/contracts/TestCurrencyAC.sol
+++ b/contracts/TestCurrencyAC.sol
@@ -1,0 +1,28 @@
+//SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+import {AccessControl} from "@openzeppelin/contracts/access/AccessControl.sol";
+import {TestCurrency} from "./TestCurrency.sol";
+
+contract TestCurrencyAC is TestCurrency, AccessControl {
+  bytes32 public constant MINTER_ROLE = keccak256("MINTER_ROLE");
+  bytes32 public constant BURNER_ROLE = keccak256("BURNER_ROLE");
+
+  constructor(
+    string memory name_,
+    string memory symbol_,
+    uint256 initialSupply,
+    uint8 decimals_,
+    address admin
+  ) TestCurrency(name_, symbol_, initialSupply, decimals_) {
+    _grantRole(DEFAULT_ADMIN_ROLE, admin);
+  }
+
+  function mint(address recipient, uint256 amount) public override onlyRole(MINTER_ROLE) {
+    super.mint(recipient, amount);
+  }
+
+  function burn(address recipient, uint256 amount) public override onlyRole(BURNER_ROLE) {
+    super.burn(recipient, amount);
+  }
+}

--- a/contracts/TestERC4626.sol
+++ b/contracts/TestERC4626.sol
@@ -4,7 +4,11 @@ pragma solidity ^0.8.0;
 import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import {ERC4626} from "@openzeppelin/contracts/token/ERC20/extensions/ERC4626.sol";
 import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
-import {TestCurrency} from "./TestCurrency.sol";
+
+interface IMintable {
+  function mint(address recipient, uint256 amount) external;
+  function burn(address recipient, uint256 amount) external;
+}
 
 contract TestERC4626 is ERC4626 {
   bool internal _broken;
@@ -58,9 +62,9 @@ contract TestERC4626 is ERC4626 {
    */
   function discreteEarning(int256 assets) external {
     if (assets > 0) {
-      TestCurrency(asset()).mint(address(this), uint256(assets));
+      IMintable(asset()).mint(address(this), uint256(assets));
     } else {
-      TestCurrency(asset()).burn(address(this), uint256(-assets));
+      IMintable(asset()).burn(address(this), uint256(-assets));
     }
   }
 

--- a/js/test-utils.js
+++ b/js/test-utils.js
@@ -8,7 +8,10 @@ const { Assertion } = require("chai");
 const { ethers } = hre;
 
 async function initCurrency(options, initial_targets, initial_balances) {
-  const Currency = await ethers.getContractFactory(options.contractClass || "TestCurrency");
+  const extraArgs = options.extraArgs || [];
+  const Currency = await ethers.getContractFactory(
+    options.contractClass || (extraArgs.length == 0 ? "TestCurrency" : "TestCurrencyAC")
+  );
   let currency = await Currency.deploy(
     options.name || "Test Currency",
     options.symbol || "TEST",


### PR DESCRIPTION
For simplicity and backward compatibility with old Ensuro's TestCurrency, I removed the access control for the default TestCurrency contract.

I added TestCurrencyAC for code that was using the version with access control.

The initCurrency function should switch between one or the other depending if the extra parameter `admin` was sent.

Also, I removed the dependency between TestERC4626 and TestCurrency, just in case the project using the library already has a contract called TestCurrency.